### PR TITLE
Use current time for TOTP

### DIFF
--- a/src/OTP/TOTP.php
+++ b/src/OTP/TOTP.php
@@ -71,6 +71,7 @@ class TOTP implements OTPInterface
                 'Length must be between 1 and 10, as a consequence of RFC 6238.'
             );
         }
+        $counterValue > 0 ? $counterValue: time();
         $msg = $this->getTValue($counterValue, true);
         $bytes = \hash_hmac($this->algo, $msg, $sharedSecret, true);
 


### PR DESCRIPTION
Is it some copy pasta leftover from https://github.com/paragonie/multi_factor/blob/748e27f2ac06353b07da677db8458866a96202ae/src/OTP/HOTP.php#L58

or designed to be used like this per default (with the `time()` parameter):
```php
$totp = new OneTime($seed, new TOTP());
$code = $totp->generateCode(time());
```
?