### PR TITLE
Add changelog and cleanup unused/duplicate code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/test export-ignore
+/phpunit.xml export-ignore
+/psalm.xml export-ignore

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,9 +1,5 @@
 name: PHP Composer
-
-on:
-  push: ~
-  pull_request: ~
-
+on: [push, pull_request]
 jobs:
   build:
     name: Run tests on ${{ matrix.php }}
@@ -11,21 +7,27 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0' ]
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: shivammathur/setup-php@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2, psalm
+          tools: psalm
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - run: composer install --no-progress --prefer-dist --no-suggest
+      - name: Install Composer dependencies
+        run: composer install --no-progress
 
-      - run: psalm --output-format=github
-        if: ${{ matrix.php == '8.0' }}
+      - name: Run Psalm
+        run: psalm --output-format=github
+        if: ${{ matrix.php == '8.2' }}
 
-      - run: vendor/bin/phpunit
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /vendor/
 /composer.lock
 .phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+### Added
+- Support for PHP 8.
+- `GoogleAuth::getQRCode()` and `GoogleAuth::makeQRCodeMessage()` methods.
+- HiddenString support for secret key.
+- `GoogleAuth->defaultQRCodeSize` property (replaces the removed width and height properties).
+
+### Changed
+- PHP 7.2+ is now required.
+- Renamed `FIDOU2F` class to `OneTime`.
+- Updated [BaconQrCode](https://github.com/Bacon/BaconQrCode) dependency to v2.
+  This version has a slightly different API for rendering QR code images.
+- Test files are now excluded from Composer package.
+
+### Removed
+- `GoogleAuth->defaultQRCodeWidth` and `GoogleAuth->defaultQRCodeHeight` properties.
+
+
+## [0.2.2] - 2016-06-17
+### Changed
+- Appended HTTP query string in QR code.
+
+
+## [0.2.1] - 2016-06-17
+### Changed
+- `TOTP` and `HOTP` classes now implement `OTPInterface`.
+
+
+## [0.2.0] - 2016-06-16
+### Added
+- Support for HOTP and Google Authenticator.
+- Range check to ensure that code length is between 1 and 10.
+
+### Changed
+- Replaced giant switch statement with `**` operator.
+- Improved readme.
+
+
+## [0.1.0] - 2016-06-13
+- Initial pre-release
+
+
+[Unreleased]: https://github.com/paragonie/multi_factor/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/paragonie/multi_factor/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/paragonie/multi_factor/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/paragonie/multi_factor/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/paragonie/multi_factor/tree/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for PHP 8.
+- Native property type declarations.
 - `GoogleAuth::getQRCode()` and `GoogleAuth::makeQRCodeMessage()` methods.
 - HiddenString support for secret key.
 - `GoogleAuth->defaultQRCodeSize` property (replaces the removed width and height properties).
 
 ### Changed
-- PHP 7.2+ is now required.
+- PHP 7.4+ is now required.
 - Renamed `FIDOU2F` class to `OneTime`.
 - Updated [BaconQrCode](https://github.com/Bacon/BaconQrCode) dependency to v2.
   This version has a slightly different API for rendering QR code images.
 - Test files are now excluded from Composer package.
+- Unified internal code for HOTP value generation.
 
 ### Removed
 - `GoogleAuth->defaultQRCodeWidth` and `GoogleAuth->defaultQRCodeHeight` properties.
+- Unused internal `rawOutput` option.
 
 
 ## [0.2.2] - 2016-06-17

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ needs.
 
 ## Requirements
 
-* PHP 7.2+
+* PHP 7.4+
   * As per [Paragon Initiative Enterprise's commitment to open source](https://paragonie.com/blog/2016/04/go-php-7-our-commitment-maintaining-our-open-source-projects),
     all new software will no longer be written for PHP 5.
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ composer require paragonie/multi-factor
 
 ## Example Usage
 
+### Display QR code
+
+```php
+<?php
+use ParagonIE\MultiFactor\Vendor\GoogleAuth;
+
+$seed = random_bytes(20);
+$auth = new GoogleAuth($seed);
+$auth->makeQRCode(null, 'php://output', 'email@example.com', 'Issuer', 'Label');
+```
+
+### Validate two-factor code
+
 ```php
 <?php
 use ParagonIE\MultiFactor\OneTime;
 use ParagonIE\MultiFactor\OTP\TOTP;
-
-$seed = random_bytes(20);
 
 // You can use TOTP or HOTP
 $otp = new OneTime($seed, new TOTP());

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
     "source":   "https://github.com/paragonie/multi_factor"
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "bacon/bacon-qr-code": "^2",
     "paragonie/constant_time_encoding": "^2",
-    "paragonie/hidden-string": "^1"
+    "paragonie/hidden-string": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8",
+    "phpunit/phpunit": "^9.5",
     "psalm/plugin-phpunit": "^0.15",
     "vimeo/psalm": "^4.6.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "psalm/plugin-phpunit": "^0.15",
-    "vimeo/psalm": "^4.6.4"
+    "psalm/plugin-phpunit": "^0.18.4",
+    "vimeo/psalm": "^5.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "require-dev": {
     "phpunit/phpunit": "^8",
     "psalm/plugin-phpunit": "^0.15",
-    "vimeo/psalm": "^4.4"
+    "vimeo/psalm": "^4.6.4"
   },
   "autoload": {
     "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="2"
+    errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/MultiFactorInterface.php
+++ b/src/MultiFactorInterface.php
@@ -14,16 +14,11 @@ interface MultiFactorInterface
 {
     /**
      * This should return a one-time password the user should enter.
-     *
-     * @return string
      */
     public function generateCode(): string;
 
     /**
      * This should validate a code for a particular user.
-     *
-     * @param string $code
-     * @return bool
      */
     public function validateCode(string $code): bool;
 }

--- a/src/OTP/HOTP.php
+++ b/src/OTP/HOTP.php
@@ -39,7 +39,7 @@ class HOTP implements OTPInterface
     public function getCode($sharedSecret, int $counterValue): string
     {
         $key = is_string($sharedSecret) ? $sharedSecret : $sharedSecret->getString();
-        $msg = $this->getTValue($counterValue, true);
+        $msg = $this->getTValue($counterValue);
         return self::generateHOTPValue($this->length, $key, $this->algo, $msg);
     }
 
@@ -51,7 +51,7 @@ class HOTP implements OTPInterface
     /**
      * Get the binary T value
      */
-    protected function getTValue(int $counter, bool $rawOutput = false): string
+    protected function getTValue(int $counter): string
     {
         $hex = \str_pad(
             \dechex($counter),
@@ -59,10 +59,8 @@ class HOTP implements OTPInterface
             '0',
             STR_PAD_LEFT
         );
-        if ($rawOutput) {
-            return Hex::decode($hex);
-        }
-        return $hex;
+
+        return Hex::decode($hex);
     }
 
     /**

--- a/src/OTP/HOTP.php
+++ b/src/OTP/HOTP.php
@@ -14,15 +14,8 @@ use ParagonIE\HiddenString\HiddenString;
  */
 class HOTP implements OTPInterface
 {
-    /**
-     * @var string
-     */
-    protected $algo;
-
-    /**
-     * @var int
-     */
-    protected $length;
+    protected string $algo;
+    protected int $length;
 
     /**
      * @param int $length          How many digits should each HOTP be?

--- a/src/OTP/TOTP.php
+++ b/src/OTP/TOTP.php
@@ -46,7 +46,7 @@ class TOTP implements OTPInterface
     public function getCode($sharedSecret, int $counterValue): string
     {
         $key = is_string($sharedSecret) ? $sharedSecret : $sharedSecret->getString();
-        $msg = $this->getTValue($counterValue, true);
+        $msg = $this->getTValue($counterValue);
         return HOTP::generateHOTPValue($this->length, $key, $this->algo, $msg);
     }
 
@@ -63,7 +63,7 @@ class TOTP implements OTPInterface
     /**
      * Get the binary T value
      */
-    protected function getTValue(int $unixTimestamp, bool $rawOutput = false): string
+    protected function getTValue(int $unixTimestamp): string
     {
         $value = \intdiv(
             $unixTimestamp - $this->timeZero,
@@ -71,15 +71,14 @@ class TOTP implements OTPInterface
                 ? $this->timeStep
                 : 1
         );
+
         $hex = \str_pad(
             \dechex($value),
             16,
             '0',
             STR_PAD_LEFT
         );
-        if ($rawOutput) {
-            return Hex::decode($hex);
-        }
-        return $hex;
+
+        return Hex::decode($hex);
     }
 }

--- a/src/OTP/TOTP.php
+++ b/src/OTP/TOTP.php
@@ -11,29 +11,12 @@ use ParagonIE\HiddenString\HiddenString;
  */
 class TOTP implements OTPInterface
 {
-    /**
-     * @var string
-     */
-    protected $algo;
+    protected string $algo;
+    protected int $length;
+    protected int $timeStep;
+    protected int $timeZero;
 
     /**
-     * @var int
-     */
-    protected $length;
-
-    /**
-     * @var int
-     */
-    protected $timeStep;
-
-    /**
-     * @var int
-     */
-    protected $timeZero;
-
-    /**
-     * TOTP constructor.
-     *
      * @param int $timeZero        The start time for calculating the TOTP
      * @param int $timeStep        How many seconds should each TOTP live?
      * @param int $length          How many digits should each TOTP be?

--- a/src/OneTime.php
+++ b/src/OneTime.php
@@ -29,11 +29,11 @@ class OneTime implements MultiFactorInterface
      * FIDOU2F constructor.
      *
      * @param string|HiddenString $secretKey
-     * @param OTPInterface $otp
+     * @param OTPInterface|null $otp
      */
     public function __construct(
         $secretKey = '',
-        OTPInterface $otp = null
+        ?OTPInterface $otp = null
     ) {
         $this->secretKey = ($secretKey instanceof HiddenString) ? $secretKey : new HiddenString($secretKey);
         if (!$otp) {
@@ -44,9 +44,6 @@ class OneTime implements MultiFactorInterface
 
     /**
      * Generate a TOTP code for 2FA
-     *
-     * @param int $counterValue
-     * @return string
      */
     public function generateCode(int $counterValue = 0): string
     {
@@ -58,10 +55,6 @@ class OneTime implements MultiFactorInterface
 
     /**
      * Validate a user-provided code
-     *
-     * @param string $code
-     * @param int $counterValue
-     * @return bool
      */
     public function validateCode(string $code, int $counterValue = 0): bool
     {

--- a/src/OneTime.php
+++ b/src/OneTime.php
@@ -15,19 +15,10 @@ use ParagonIE\HiddenString\HiddenString;
  */
 class OneTime implements MultiFactorInterface
 {
-    /**
-     * @var OTPInterface
-     */
-    protected $otp;
+    protected OTPInterface $otp;
+    protected HiddenString $secretKey;
 
     /**
-     * @var HiddenString
-     */
-    protected $secretKey;
-
-    /**
-     * FIDOU2F constructor.
-     *
      * @param string|HiddenString $secretKey
      * @param OTPInterface|null $otp
      */
@@ -36,7 +27,7 @@ class OneTime implements MultiFactorInterface
         ?OTPInterface $otp = null
     ) {
         $this->secretKey = ($secretKey instanceof HiddenString) ? $secretKey : new HiddenString($secretKey);
-        if (!$otp) {
+        if ($otp === null) {
             $otp = new TOTP();
         }
         $this->otp = $otp;

--- a/src/Vendor/GoogleAuth.php
+++ b/src/Vendor/GoogleAuth.php
@@ -19,10 +19,7 @@ use \ParagonIE\MultiFactor\OTP\{
  */
 class GoogleAuth extends OneTime
 {
-    /**
-     * @var int
-     */
-    public $defaultQRCodeSize = 384;
+    public int $defaultQRCodeSize = 384;
 
     /**
      * Create a QR code to load the key onto the device

--- a/src/Vendor/GoogleAuth.php
+++ b/src/Vendor/GoogleAuth.php
@@ -24,17 +24,16 @@ class GoogleAuth extends OneTime
     /**
      * Create a QR code to load the key onto the device
      *
-     * @param Writer $qrCodeWriter
+     * @param Writer|null $qrCodeWriter
      * @param string $outFile        Where to store the QR code?
      * @param string $username       Username or email address
      * @param string $issuer         Optional
      * @param string $label          Optional
      * @param int $initialCounter    Initial counter value
-     * @return void
      * @throws \Exception
      */
     public function makeQRCode(
-        Writer $qrCodeWriter = null,
+        ?Writer $qrCodeWriter = null,
         string $outFile = 'php://output',
         string $username = '',
         string $issuer = '',
@@ -47,7 +46,7 @@ class GoogleAuth extends OneTime
     }
 
     public function getQRCode(
-        Writer $qrCodeWriter = null,
+        ?Writer $qrCodeWriter = null,
         string $username = '',
         string $issuer = '',
         string $label = '',
@@ -71,6 +70,7 @@ class GoogleAuth extends OneTime
         } else {
             throw new \Exception('Not implemented');
         }
+
         if ($label) {
             $message .= \urlencode(
                 \str_replace(':', '', $label)
@@ -81,21 +81,25 @@ class GoogleAuth extends OneTime
         $args = [
             'secret' => Base32::encode($this->secretKey->getString())
         ];
+
         if ($issuer) {
             $args['issuer'] = $issuer;
         }
+
         $args['digits'] = $this->otp->getLength();
+
         if ($this->otp instanceof TOTP) {
             $args['period'] = $this->otp->getTimeStep();
         } else {
             $args['counter'] = $initialCounter;
         }
+
         $message .= '?' . \http_build_query($args);
 
         return $message;
     }
 
-    protected function makeQRCodeWriteOrDefault(Writer $qrCodeWriter = null) : Writer
+    protected function makeQRCodeWriteOrDefault(?Writer $qrCodeWriter): Writer
     {
         // Sane default; You can dependency-inject a replacement:
         if (!$qrCodeWriter) {

--- a/test/GoogleAuthTest.php
+++ b/test/GoogleAuthTest.php
@@ -12,7 +12,7 @@ use \PHPUnit\Framework\TestCase;
 class GoogleAuthTest extends TestCase
 {
     /**
-     * @psalm-return Generator<int, array{0:string, 1:string, 2:string, 3:string, 4:int, 5:GoogleAuth, 6:Writer|null}>
+     * @return Generator<int, array{0:string, 1:string, 2:string, 3:string, 4:int, 5:GoogleAuth, 6:Writer|null}>
      */
     public function dataProviderMakeQRCodeMessage() : Generator
     {

--- a/test/HOTPTest.php
+++ b/test/HOTPTest.php
@@ -35,7 +35,7 @@ class HOTPTest extends TestCase
     /**
      * @dataProvider dataProviderFailureOfGetCode
      *
-     * @psalm-param class-string<\Throwable> $expectedException
+     * @param class-string<Throwable> $expectedException
      */
     public function testFailureOfGetCode(
         int $length,
@@ -55,7 +55,7 @@ class HOTPTest extends TestCase
     }
 
     /**
-     * @psalm-return array<int, array{0:int, 1:class-string<\Throwable>, 2:string, 3:string, 4:int}>
+     * @return array<int, array{0:int, 1:class-string<Throwable>, 2:string, 3:string, 4:int}>
      */
     public function dataProviderFailureOfGetCode(): array
     {

--- a/test/TOTPTest.php
+++ b/test/TOTPTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Class TOTPTest
  */
-class TOPTTest extends TestCase
+class TOTPTest extends TestCase
 {
     /**
      * Test vectors from RFC 6238
@@ -32,7 +32,7 @@ class TOPTTest extends TestCase
         );
 
         /**
-        * @psalm-var array<int, array{time:int, outputs:array{sha1:string, sha256:string, sha512:string}}>
+        * @var array<int, array{time:int, outputs:array{sha1:string, sha256:string, sha512:string}}> $testVectors
         */
         $testVectors = [
             [
@@ -173,8 +173,7 @@ class TOPTTest extends TestCase
      * @dataProvider dataProviderFailureOfGetCode
      *
      * @param array{0:int, 1:int, 2:int, 3:string} $constructorArgs
-     *
-     * @psalm-param class-string<\Throwable> $expectedException
+     * @param class-string<Throwable> $expectedException
      */
     public function testFailureOfGetCode(
         array $constructorArgs,
@@ -195,7 +194,7 @@ class TOPTTest extends TestCase
     }
 
     /**
-     * @psalm-return Generator<int, array{0:array{0:int, 1:int, 2:int, 3:string}, 1:class-string<\Throwable>, 2:string, 3:string, 4:int}, mixed, void>
+     * @return Generator<int, array{0:array{0:int, 1:int, 2:int, 3:string}, 1:class-string<Throwable>, 2:string, 3:string, 4:int}, mixed, void>
      */
     public function dataProviderFailureOfGetCode(): \Generator
     {


### PR DESCRIPTION
This brings over the improvements I made in my fork over the past couple of years.

* Removed duplicated code for HOTP value generation.
* Fixed level one static analysis warnings.
* Added full changelog.
* Added property type declarations.
* PHP 7.4+ is now required.

Commits should not be squashed since each one is a standalone improvement.